### PR TITLE
fix for kvs inline credentials

### DIFF
--- a/backpack/kvs.py
+++ b/backpack/kvs.py
@@ -165,7 +165,7 @@ class KVSCredentialsHandler(ABC):
         if aws_access_key_id or aws_secret_access_key:
             self.session = boto3.Session(
                 aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_access_key_id
+                aws_secret_access_key=aws_secret_access_key
             )
         else:
             self.session = boto3.Session()


### PR DESCRIPTION
Fixed typo when setting boto3 session via KVSInlineCredentialsHandler. Was setting the 'aws_access_key_id' as the 'aws_secret_access_key'